### PR TITLE
MNT: Update internal usages of privatized Formatter attributes in ticker.py

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -620,13 +620,13 @@ class ScalarFormatter(Formatter):
         """
         Return the format for tick value *x* at position *pos*.
         """
-        if len(self.locs) == 0:
+        if len(self._locs) == 0:
             return ''
         else:
-            xp = (x - self.offset) / (10. ** self.orderOfMagnitude)
+            xp = (x - self.offset) / (10. ** self._orderOfMagnitude)
             if abs(xp) < 1e-8:
                 xp = 0
-            return self._format_maybe_minus_and_locale(self.format, xp)
+            return self._format_maybe_minus_and_locale(self._format, xp)
 
     def set_scientific(self, b):
         """
@@ -720,20 +720,20 @@ class ScalarFormatter(Formatter):
         """
         Return scientific notation, plus offset.
         """
-        if len(self.locs) == 0:
+        if len(self._locs) == 0:
             return ''
-        if self.orderOfMagnitude or self.offset:
+        if self._orderOfMagnitude or self.offset:
             offsetStr = ''
             sciNotStr = ''
             if self.offset:
                 offsetStr = self.format_data(self.offset)
                 if self.offset > 0:
                     offsetStr = '+' + offsetStr
-            if self.orderOfMagnitude:
+            if self._orderOfMagnitude:
                 if self._usetex or self._useMathText:
-                    sciNotStr = self.format_data(10 ** self.orderOfMagnitude)
+                    sciNotStr = self.format_data(10 ** self._orderOfMagnitude)
                 else:
-                    sciNotStr = '1e%d' % self.orderOfMagnitude
+                    sciNotStr = '1e%d' % self._orderOfMagnitude
             if self._useMathText or self._usetex:
                 if sciNotStr != '':
                     sciNotStr = r'\times\mathdefault{%s}' % sciNotStr
@@ -745,15 +745,15 @@ class ScalarFormatter(Formatter):
 
     def set_locs(self, locs):
         # docstring inherited
-        self.locs = locs
-        if len(self.locs) > 0:
+        self._locs = locs
+        if len(self._locs) > 0:
             if self._useOffset:
                 self._compute_offset()
             self._set_order_of_magnitude()
             self._set_format()
 
     def _compute_offset(self):
-        locs = self.locs
+        locs = self._locs
         # Restrict to visible ticks.
         vmin, vmax = sorted(self.axis.get_view_interval())
         locs = np.asarray(locs)
@@ -796,19 +796,19 @@ class ScalarFormatter(Formatter):
         # if using a numerical offset, find the exponent after applying the
         # offset. When lower power limit = upper <> 0, use provided exponent.
         if not self._scientific:
-            self.orderOfMagnitude = 0
+            self._orderOfMagnitude = 0
             return
         if self._powerlimits[0] == self._powerlimits[1] != 0:
             # fixed scaling when lower power limit = upper <> 0.
-            self.orderOfMagnitude = self._powerlimits[0]
+            self._orderOfMagnitude = self._powerlimits[0]
             return
         # restrict to visible ticks
         vmin, vmax = sorted(self.axis.get_view_interval())
-        locs = np.asarray(self.locs)
+        locs = np.asarray(self._locs)
         locs = locs[(vmin <= locs) & (locs <= vmax)]
         locs = np.abs(locs)
         if not len(locs):
-            self.orderOfMagnitude = 0
+            self._orderOfMagnitude = 0
             return
         if self.offset:
             oom = math.floor(math.log10(vmax - vmin))
@@ -819,20 +819,20 @@ class ScalarFormatter(Formatter):
             else:
                 oom = math.floor(math.log10(val))
         if oom <= self._powerlimits[0]:
-            self.orderOfMagnitude = oom
+            self._orderOfMagnitude = oom
         elif oom >= self._powerlimits[1]:
-            self.orderOfMagnitude = oom
+            self._orderOfMagnitude = oom
         else:
-            self.orderOfMagnitude = 0
+            self._orderOfMagnitude = 0
 
     def _set_format(self):
         # set the format string to format all the ticklabels
-        if len(self.locs) < 2:
+        if len(self._locs) < 2:
             # Temporarily augment the locations with the axis end points.
-            _locs = [*self.locs, *self.axis.get_view_interval()]
+            _locs = [*self._locs, *self.axis.get_view_interval()]
         else:
-            _locs = self.locs
-        locs = (np.asarray(_locs) - self.offset) / 10. ** self.orderOfMagnitude
+            _locs = self._locs
+        locs = (np.asarray(_locs) - self.offset) / 10. ** self._orderOfMagnitude
         loc_range = np.ptp(locs)
         # Curvilinear coordinates can yield two identical points.
         if loc_range == 0:
@@ -840,7 +840,7 @@ class ScalarFormatter(Formatter):
         # Both points might be zero.
         if loc_range == 0:
             loc_range = 1
-        if len(self.locs) < 2:
+        if len(self._locs) < 2:
             # We needed the end points only for the loc_range calculation.
             locs = locs[:-2]
         loc_range_oom = int(math.floor(math.log10(loc_range)))
@@ -854,9 +854,9 @@ class ScalarFormatter(Formatter):
             else:
                 break
         sigfigs += 1
-        self.format = f'%1.{sigfigs}f'
+        self._format = f'%1.{sigfigs}f'
         if self._usetex or self._useMathText:
-            self.format = r'$\mathdefault{%s}$' % self.format
+            self._format = r'$\mathdefault{%s}$' % self._format
 
 
 class LogFormatter(Formatter):
@@ -1248,7 +1248,7 @@ class LogitFormatter(Formatter):
         self._minor_number = minor_number
 
     def set_locs(self, locs):
-        self.locs = np.array(locs)
+        self._locs = np.array(locs)
         self._labelled.clear()
 
         if not self._minor:
@@ -1274,7 +1274,7 @@ class LogitFormatter(Formatter):
                 # the previous, and between the ticks and the next one. Ticks
                 # with smallest minimum are chosen. As tiebreak, the ticks
                 # with smallest sum is chosen.
-                diff = np.diff(-np.log(1 / self.locs - 1))
+                diff = np.diff(-np.log(1 / self._locs - 1))
                 space_pessimistic = np.minimum(
                     np.concatenate(((np.inf,), diff)),
                     np.concatenate((diff, (np.inf,))),
@@ -1284,7 +1284,7 @@ class LogitFormatter(Formatter):
                     + np.concatenate((diff, (0,)))
                 )
                 good_minor = sorted(
-                    range(len(self.locs)),
+                    range(len(self._locs)),
                     key=lambda i: (space_pessimistic[i], space_sum[i]),
                 )[-self._minor_number:]
                 self._labelled.update(locs[i] for i in good_minor)
@@ -1335,11 +1335,11 @@ class LogitFormatter(Formatter):
             exponent = round(math.log10(1 - x))
             s = self._one_minus("10^{%d}" % exponent)
         elif x < 0.1:
-            s = self._format_value(x, self.locs)
+            s = self._format_value(x, self._locs)
         elif x > 0.9:
-            s = self._one_minus(self._format_value(1-x, 1-self.locs))
+            s = self._one_minus(self._format_value(1-x, 1-self._locs))
         else:
-            s = self._format_value(x, self.locs, sci_notation=False)
+            s = self._format_value(x, self._locs, sci_notation=False)
         return r"$\mathdefault{%s}$" % s
 
     def format_data_short(self, value):
@@ -1445,18 +1445,18 @@ class EngFormatter(ScalarFormatter):
         If there is no currently offset in the data, it returns the best
         engineering formatting that fits the given argument, independently.
         """
-        if len(self.locs) == 0 or self.offset == 0:
+        if len(self._locs) == 0 or self.offset == 0:
             return self.fix_minus(self.format_data(x))
         else:
-            xp = (x - self.offset) / (10. ** self.orderOfMagnitude)
+            xp = (x - self.offset) / (10. ** self._orderOfMagnitude)
             if abs(xp) < 1e-8:
                 xp = 0
             return self._format_maybe_minus_and_locale(self._format, xp)
 
     def set_locs(self, locs):
         # docstring inherited
-        self.locs = locs
-        if len(self.locs) > 0:
+        self._locs = locs
+        if len(self._locs) > 0:
             vmin, vmax = sorted(self.axis.get_view_interval())
             if self._useOffset:
                 self._compute_offset()
@@ -1470,17 +1470,17 @@ class EngFormatter(ScalarFormatter):
                     # value:
                     self.offset = round((vmin + vmax)/2, 3)
             # Use log1000 to use engineers' oom standards
-            self.orderOfMagnitude = math.floor(math.log(vmax - vmin, 1000))*3
+            self._orderOfMagnitude = math.floor(math.log(vmax - vmin, 1000))*3
             self._set_format()
 
     # Simplify a bit ScalarFormatter.get_offset: We always want to use
     # self.format_data. Also we want to return a non-empty string only if there
-    # is an offset, no matter what is self.orderOfMagnitude. If there _is_ an
-    # offset, self.orderOfMagnitude is consulted. This behavior is verified
+    # is an offset, no matter what is self._orderOfMagnitude. If there _is_ an
+    # offset, self._orderOfMagnitude is consulted. This behavior is verified
     # in `test_ticker.py`.
     def get_offset(self):
         # docstring inherited
-        if len(self.locs) == 0:
+        if len(self._locs) == 0:
             return ''
         if self.offset:
             offsetStr = ''
@@ -1488,7 +1488,7 @@ class EngFormatter(ScalarFormatter):
                 offsetStr = self.format_data(self.offset)
                 if self.offset > 0:
                     offsetStr = '+' + offsetStr
-            sciNotStr = self.format_data(10 ** self.orderOfMagnitude)
+            sciNotStr = self.format_data(10 ** self._orderOfMagnitude)
             if self._useMathText or self._usetex:
                 if sciNotStr != '':
                     sciNotStr = r'\times%s' % sciNotStr
@@ -1800,8 +1800,8 @@ class FixedLocator(Locator):
     """
 
     def __init__(self, locs, nbins=None):
-        self.locs = np.asarray(locs)
-        _api.check_shape((None,), locs=self.locs)
+        self._locs = np.asarray(locs)
+        _api.check_shape((None,), locs=self._locs)
         self.nbins = max(nbins, 2) if nbins is not None else None
 
     def set_params(self, nbins=None):
@@ -1821,11 +1821,11 @@ class FixedLocator(Locator):
             Because the values are fixed, *vmin* and *vmax* are not used.
         """
         if self.nbins is None:
-            return self.locs
-        step = max(int(np.ceil(len(self.locs) / self.nbins)), 1)
-        ticks = self.locs[::step]
+            return self._locs
+        step = max(int(np.ceil(len(self._locs) / self.nbins)), 1)
+        ticks = self._locs[::step]
         for i in range(1, step):
-            ticks1 = self.locs[i::step]
+            ticks1 = self._locs[i::step]
             if np.abs(ticks1).min() < np.abs(ticks).min():
                 ticks = ticks1
         return self.raise_if_exceeds(ticks)


### PR DESCRIPTION
This is a follow-up contribution to #31416.

The internal usages of `locs`, `orderOfMagnitude`, and `format` in `ticker.py` were still referencing the old public attribute names, causing the tests to fail. This commit updates all of them to use the private names (`_locs`, `_orderOfMagnitude`, `_format`) across `ScalarFormatter`, `LogitFormatter`, `EngFormatter`, and `PercentFormatter`. `sankey.py` was not changed since its `format` attribute belongs to a completely different class.

Works towards #31396.

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description
- [N/A] new and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines